### PR TITLE
Update CI to enable PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,8 @@ on:
       - main
   workflow_dispatch:
   pull_request:
-#   Placeholder for the future if this work gets accepted into the upstream repo
-#   release:
-#     types: [published]
+  release:
+    types: [published]
 
 jobs:
   run-tests:
@@ -19,7 +18,6 @@ jobs:
             - '3.10'
             - '3.11'
             - '3.12'
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -32,25 +30,25 @@ jobs:
         python -m pip install .'[testing]'
     - name: Test with tox
       run: tox
-
-#   Placeholder for the future if this work gets accepted into the upstream repo
-#   release:
-#     name: Release to PyPI
-#     if: github.event_name == 'release' && github.event.action == 'published'
-#     needs:
-#       - run-tests
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#       - uses: actions/setup-python@v5
-#         with:
-#           python-version: 3.11
-#       - name: Install dependencies for package building only
-#         run: pip install build
-#       - name: Build package for upload to PyPI
-#         run: python -m build .
-#       - name: Upload the distribution to PyPI
-#         uses: pypa/gh-action-pypi-publish@v1.4.2
-#         with:
-#           user: __token__
-#           password: ${{ secrets.PYPI_API_TOKEN }}
+  release:
+    name: Release to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs:
+      - run-tests
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wagtaildraftsharing
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install dependencies for package building only
+        run: pip install build
+      - name: Build package for upload to PyPI
+        run: python -m build .
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ dist/
 
 # IDEs
 .idea/
+.vim
+.nvimrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Added
 
-- Support for **Wagtail 6**, including a Stimulus JS controller to replace legacy JS.
-- New option to generate a **draft sharing link from the Action Menu** when a page has an unpublished draft.
-- **Customizable verbose names** for draft sharing, implemented in a non-breaking way.
-- **Customizable position** for the draft sharing menu item.
-- **GitHub Actions CI** using `tox` and Python versions 3.9 to 3.12.
+- Support for **Wagtail 6**, including a Stimulus JS controller to replace legacy JS. (@stevejalim)
+- New option to generate a **draft sharing link from the Action Menu** when a page has an unpublished draft. (@stevejalim)
+- **Customizable verbose names** for draft sharing, implemented in a non-breaking way. (@stevejalim)
+- **Customizable position** for the draft sharing menu item. (@stevejalim)
+- **GitHub Actions CI** using `tox` and Python versions 3.9 to 3.12. (@stevejalim)
 
 
 ### Changed
 
-- **Menu icon** for draft sharing has been updated.
-- Dropped Python 3.8 support (EOL).
+- **Menu icon** for draft sharing has been updated. (@stevejalim)
+- Dropped Python 3.8 support (EOL). (@stevejalim)
 
 ---
 
@@ -22,4 +22,4 @@
 
 ### Added
 
-- Initial release.
+- Initial release. (@KIRA009)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Support for **Wagtail 6**, including a Stimulus JS controller to replace legacy JS.
+- New option to generate a **draft sharing link from the Action Menu** when a page has an unpublished draft.
+- **Customizable verbose names** for draft sharing, implemented in a non-breaking way.
+- **Customizable position** for the draft sharing menu item.
+- **GitHub Actions CI** using `tox` and Python versions 3.9 to 3.12.
+
+
+### Changed
+
+- **Menu icon** for draft sharing has been updated.
+- Dropped Python 3.8 support (EOL).
+
+---
+
+## [0.0.4] - 2024-01-30
+
+### Added
+
+- Initial release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 testing = [
     "coverage[toml]",
     "tox",
+    "tox-gh-actions",
     "wagtail-factories",
     "freezegun==1.5.1",
 ]


### PR DESCRIPTION
When applied, this PR will:

- Ensure that tox-gh-actions is installed in CI
- Prepare PyPI release step via trusted publishing
- Add CHANGELOG