### PR TITLE
Add handling when Clipboard API is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - **Customizable verbose names** for draft sharing, implemented in a non-breaking way. (@stevejalim)
 - **Customizable position** for the draft sharing menu item. (@stevejalim)
 - **GitHub Actions CI** using `tox` and Python versions 3.9 to 3.12. (@stevejalim)
-
+- Add fallback handling if the Clipboard API is not available. (@mixxorz)
 
 ### Changed
 


### PR DESCRIPTION
On some browsers (like Safari), the Clipboard API can be restricted if it's used outside of a direct user interactions such as within a fetch's response handler IF the browsing context is not secure (not on HTTPS). When this happens, clicking "Copy draft sharing link" will hang. I ran into this issue while testing on localhost (which is not HTTPS) on Safari.

This PR adds fallback handling for this scenario which displays a Success banner with the draft sharing URL on the top of the page instead.