### PR TITLE
Remove revision dropdown on draft sharing link edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the ability to change which revision is shared on the draft sharing link edit page. (@mixxorz)
+
 ---
 
 ## [0.2.0] - 2025-03-028

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wagtaildraftsharing"
-version = "0.2.0"
+version = "0.3.0"
 description = "Share wagtail drafts with private URLs."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -73,14 +73,14 @@ deps=
     wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
-basepython=python3.11
+basepython=python3.12
 deps=
     ruff
 commands=
     ruff check wagtaildraftsharing testmanage.py
 
 [testenv:coverage]
-basepython=python3.11
+basepython=python3.12
 deps=
     coverage[toml]
     wagtail-factories
@@ -91,7 +91,7 @@ commands=
     coverage xml
 
 [testenv:interactive]
-basepython=python3.11
+basepython=python3.12
 deps=
     wagtail>=5.2,<5.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,53 @@
 [tox]
 skipsdist=True
-envlist=
+
+# Compatibility summary:
+#
+# Python vs Django
+# ----------------
+# Python 3.9   → Django 4.2 only
+# Python 3.10+ → Django 4.2, 5.1, 5.2
+#
+# Django vs Wagtail
+# -----------------
+# Django 4.2 → Wagtail 5.2, 6.3, 6.4, 7.0
+# Django 5.1 → Wagtail 6.3, 6.4, 7.0
+# Django 5.2 → Wagtail 6.3, 7.0
+
+envlist =
     lint,
-    python{3.9,3.10,3.11,3.12}-django{4.2,5.1,5.2}-wagtail{5.2,6.3,6.4,7.0},
-    coverage
+    coverage,
+    python3.9-django4.2-wagtail5.2,
+    python3.9-django4.2-wagtail6.3,
+    python3.9-django4.2-wagtail6.4,
+    python3.9-django4.2-wagtail7.0,
+    python3.10-django4.2-wagtail5.2,
+    python3.10-django4.2-wagtail6.3,
+    python3.10-django4.2-wagtail6.4,
+    python3.10-django4.2-wagtail7.0,
+    python3.10-django5.1-wagtail6.3,
+    python3.10-django5.1-wagtail6.4,
+    python3.10-django5.1-wagtail7.0,
+    python3.10-django5.2-wagtail6.3,
+    python3.10-django5.2-wagtail7.0,
+    python3.11-django4.2-wagtail5.2,
+    python3.11-django4.2-wagtail6.3,
+    python3.11-django4.2-wagtail6.4,
+    python3.11-django4.2-wagtail7.0,
+    python3.11-django5.1-wagtail6.3,
+    python3.11-django5.1-wagtail6.4,
+    python3.11-django5.1-wagtail7.0,
+    python3.11-django5.2-wagtail6.3,
+    python3.11-django5.2-wagtail7.0,
+    python3.12-django4.2-wagtail5.2,
+    python3.12-django4.2-wagtail6.3,
+    python3.12-django4.2-wagtail6.4,
+    python3.12-django4.2-wagtail7.0,
+    python3.12-django5.1-wagtail6.3,
+    python3.12-django5.1-wagtail6.4,
+    python3.12-django5.1-wagtail7.0,
+    python3.12-django5.2-wagtail6.3,
+    python3.12-django5.2-wagtail7.0
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -66,7 +110,7 @@ setenv=
 # Running tox in GHA without redefining it all in a GHA matrix:
 # https://github.com/ymyzk/tox-gh-actions
 python =
-    3.9: python3.9-django4.2
+    3.9: python3.9
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12

--- a/tox.ini
+++ b/tox.ini
@@ -113,4 +113,4 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
-    3.12: python3.12
+    3.12: python3.12, lint, coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.9,3.10,3.11,3.12}-django{3.2,4.2,5.1}-wagtail{5.1,5.2,6.1,6.2},
+    python{3.9,3.10,3.11,3.12}-django{4.2,5.1,5.2}-wagtail{5.2,6.3,6.4,7.0},
     coverage
 
 [testenv]
@@ -20,14 +20,13 @@ basepython=
     python3.12: python3.12
 
 deps=
-    wagtail5.1: wagtail>=5.1,<5.2
+    django4.2: django>=4.2,<4.3
+    django5.1: django>=5.1,<5.2
+    django5.2: django>=5.2,<5.3
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
-
-[testenv:python3.12-django3.2-wagtail6.1]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
+    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
 basepython=python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -28,38 +28,6 @@ deps=
     wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
 
-[testenv:python3.9-django5.1-wagtail5.2]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.1-wagtail6.3]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.1-wagtail6.4]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.1-wagtail7.0]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.2-wagtail5.2]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.2-wagtail6.3]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.2-wagtail6.4]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
-[testenv:python3.9-django5.2-wagtail7.0]
-# This permutation is not a valid install, but let's tolerate it
-allowlist_externals=python  # take the system python to just get tox running for this combo
-
 [testenv:lint]
 basepython=python3.11
 deps=
@@ -98,7 +66,7 @@ setenv=
 # Running tox in GHA without redefining it all in a GHA matrix:
 # https://github.com/ymyzk/tox-gh-actions
 python =
-    3.9: python3.9
+    3.9: python3.9-django4.2
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,38 @@ deps=
     wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
 
+[testenv:python3.9-django5.1-wagtail5.2]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.1-wagtail6.3]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.1-wagtail6.4]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.1-wagtail7.0]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.2-wagtail5.2]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.2-wagtail6.3]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.2-wagtail6.4]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
+[testenv:python3.9-django5.2-wagtail7.0]
+# This permutation is not a valid install, but let's tolerate it
+allowlist_externals=python  # take the system python to just get tox running for this combo
+
 [testenv:lint]
 basepython=python3.11
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ skipsdist=True
 
 envlist =
     lint,
-    coverage,
     python3.9-django4.2-wagtail5.2,
     python3.9-django4.2-wagtail6.3,
     python3.9-django4.2-wagtail6.4,
@@ -47,7 +46,8 @@ envlist =
     python3.12-django5.1-wagtail6.4,
     python3.12-django5.1-wagtail7.0,
     python3.12-django5.2-wagtail6.3,
-    python3.12-django5.2-wagtail7.0
+    python3.12-django5.2-wagtail7.0,
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/wagtaildraftsharing/snippets.py
+++ b/wagtaildraftsharing/snippets.py
@@ -1,3 +1,4 @@
+from wagtail.admin.panels import FieldPanel, ObjectList
 from wagtail.snippets.views.snippets import SnippetViewSet
 
 from wagtaildraftsharing.models import WagtaildraftsharingLink
@@ -14,6 +15,24 @@ class WagtaildraftsharingLinkSnippetViewSet(SnippetViewSet):
     add_to_admin_menu = True
     list_display = ("__str__", "is_active", "created_by", "share_url")
     list_filter = ("is_active",)
+
+    edit_handler = ObjectList([
+        FieldPanel("revision", read_only=True),
+        FieldPanel(
+            "is_active",
+            help_text=(
+                "When false, the sharing link will not be viewable."
+            )
+        ),
+        FieldPanel(
+            "active_until",
+            help_text=(
+                "The link will not be viewable after this date. "
+                "Leave blank if the link should never expire."
+            )
+        ),
+    ])
+
 
     def get_queryset(self, request):
         return WagtaildraftsharingLink.objects.all().prefetch_related(


### PR DESCRIPTION
This was loading Wagtail's entire revisions list for all pages as dropdown options, which causes strain on the database and often times out.

This interface was already quite unintuitive. I don't imagine anyone was actually using it to update the revision used on a draft sharing link. As such, I've decided to make it read-only so that the revision is still visible, but won't cause Django to query for all revisions.