### PR TITLE
Prevent creating draftsharing link snippets via admin

### DIFF
--- a/wagtaildraftsharing/snippets.py
+++ b/wagtaildraftsharing/snippets.py
@@ -2,9 +2,15 @@ from wagtail.admin.panels import FieldPanel, ObjectList
 from wagtail.snippets.views.snippets import SnippetViewSet
 
 from wagtaildraftsharing.models import WagtaildraftsharingLink
+from wagtail.permission_policies import ModelPermissionPolicy
 
 from .settings import settings as draftsharing_settings
 
+class NoAddPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, user, action):
+        if action == 'add':
+            return False
+        return super().user_has_permission(user, action)
 
 class WagtaildraftsharingLinkSnippetViewSet(SnippetViewSet):
     model = WagtaildraftsharingLink
@@ -15,6 +21,9 @@ class WagtaildraftsharingLinkSnippetViewSet(SnippetViewSet):
     add_to_admin_menu = True
     list_display = ("__str__", "is_active", "created_by", "share_url")
     list_filter = ("is_active",)
+
+    # Use custom permission policy so adding from this view is disabled
+    permission_policy = NoAddPermissionPolicy(WagtaildraftsharingLink)
 
     edit_handler = ObjectList([
         FieldPanel("revision", read_only=True),
@@ -32,7 +41,6 @@ class WagtaildraftsharingLinkSnippetViewSet(SnippetViewSet):
             )
         ),
     ])
-
 
     def get_queryset(self, request):
         return WagtaildraftsharingLink.objects.all().prefetch_related(

--- a/wagtaildraftsharing/tests/test_views.py
+++ b/wagtaildraftsharing/tests/test_views.py
@@ -10,6 +10,7 @@ from django.utils.timezone import now as timezone_now
 from wagtail_factories import PageFactory
 
 from wagtaildraftsharing.models import WagtaildraftsharingLink
+from wagtaildraftsharing.snippets import WagtaildraftsharingLinkSnippetViewSet
 from wagtaildraftsharing.views import CreateSharingLinkView, SharingLinkView
 
 User = get_user_model()
@@ -197,3 +198,27 @@ class SharingLinkViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["X-Robots-Tag"], "noindex, nofollow")
+
+
+class WagtaildraftsharingLinkSnippetAdminViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.superuser = User.objects.create_superuser(
+            username="admin",
+            password="test",
+        )
+
+    def test_snippet_list_does_not_show_add_button_for_superuser(self):
+        # Superusers would normally be allowed to add snippets, but our
+        # custom permission policy should disable the "Add" action.
+        self.client.login(username="admin", password="test")
+
+        viewset = WagtaildraftsharingLinkSnippetViewSet()
+        list_url = reverse(viewset.get_url_name("list"))
+
+        response = self.client.get(list_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Add Draftsharing Link")
+        # Occasionally the "Add Sharing Link" pops up too...
+        self.assertNotContains(response, "Add Sharing Link")


### PR DESCRIPTION
Resolves https://github.com/torchbox/wagtaildraftsharing/issues/12

Introduce a custom permission policy to disable the add action on the draftsharing link snippet viewset and add admin view tests to ensure the add button is hidden. This is opposed to creating a form here to generate a link, which seems a bit counterintuitive to me.

Before:
<img width="775" height="83" alt="image" src="https://github.com/user-attachments/assets/54a0bc37-1cb0-4201-8cc8-7c6f0cc179b8" />

After:
<img width="782" height="81" alt="image" src="https://github.com/user-attachments/assets/714336f7-44aa-40c6-bbb9-fa2b7737dd0d" />

